### PR TITLE
Enable Railcraft Crowbars to be upgraded for Sword AOE Attacks.

### DIFF
--- a/src/main/java/org/wyldmods/toolutilities/ToolUtilities.java
+++ b/src/main/java/org/wyldmods/toolutilities/ToolUtilities.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.wyldmods.toolutilities.common.CommonProxy;
 import org.wyldmods.toolutilities.common.Config;
 import org.wyldmods.toolutilities.common.compat.MekanismCompat;
+import org.wyldmods.toolutilities.common.compat.RailcraftCompat;
 import org.wyldmods.toolutilities.common.handlers.AOEHandler;
 import org.wyldmods.toolutilities.common.handlers.BrokenToolManager;
 import org.wyldmods.toolutilities.common.handlers.PlaceItem;
@@ -37,7 +38,7 @@ import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
 
-@Mod(modid = ToolUtilities.MODID, name = ToolUtilities.MODID, version = "0.0.1", guiFactory = "org.wyldmods.toolutilities.client.config.TUConfigFactory", dependencies="after:MekanismTools")
+@Mod(modid = ToolUtilities.MODID, name = ToolUtilities.MODID, version = "0.0.1", guiFactory = "org.wyldmods.toolutilities.client.config.TUConfigFactory", dependencies="after:MekanismTools;after:Railcraft")
 public class ToolUtilities
 {
 	public static final String MODID = "ToolUtilities";
@@ -90,6 +91,10 @@ public class ToolUtilities
 		{
 			MekanismCompat.addMekanismRecipes();
 		}
+        if (Loader.isModLoaded("Railcraft") && Config.railcraftModule)
+        {
+            RailcraftCompat.addRailcraftRecipes();
+        }
 	}
 
 	public void doConfig()

--- a/src/main/java/org/wyldmods/toolutilities/common/Config.java
+++ b/src/main/java/org/wyldmods/toolutilities/common/Config.java
@@ -132,7 +132,7 @@ public class Config
         mekanismModule = config.get(sectionModules, "mekanism", true).getBoolean();
         allowPaxelUpgrades = config.get(sectionModules,"mekanismPaxel", true, "Allow Mekanism Paxels to receive upgrades").getBoolean();
 
-        railcraftModule = config.get(sectionModules,"railcraft",true,"Allow Crowbars to receive some upgrades").getBoolean();
+        railcraftModule = config.get(sectionModules,"railcraft",true,"Allow Crowbars to receive Sword upgrades").getBoolean();
         
         blacklistPlace = config.get(sectionRightClick,"toolBlacklist", "", "Unlocalized name of tools for blacklisting (Comma separated)").getString().split(",");
         blacklist3x1 = config.get(sectionAreaMining,"3x1blacklist", "", "Unlocalized name of tools for blacklisting (Comma separated)").getString().split(",");

--- a/src/main/java/org/wyldmods/toolutilities/common/Config.java
+++ b/src/main/java/org/wyldmods/toolutilities/common/Config.java
@@ -53,6 +53,8 @@ public class Config
     
     public static boolean mekanismModule;
     public static boolean allowPaxelUpgrades;
+
+    public static boolean railcraftModule;
     
     public static String[] blacklistPlace;
     public static String[] blacklist3x1;
@@ -129,6 +131,8 @@ public class Config
         
         mekanismModule = config.get(sectionModules, "mekanism", true).getBoolean();
         allowPaxelUpgrades = config.get(sectionModules,"mekanismPaxel", true, "Allow Mekanism Paxels to receive upgrades").getBoolean();
+
+        railcraftModule = config.get(sectionModules,"railcraft",true,"Allow Crowbars to receive some upgrades").getBoolean();
         
         blacklistPlace = config.get(sectionRightClick,"toolBlacklist", "", "Unlocalized name of tools for blacklisting (Comma separated)").getString().split(",");
         blacklist3x1 = config.get(sectionAreaMining,"3x1blacklist", "", "Unlocalized name of tools for blacklisting (Comma separated)").getString().split(",");

--- a/src/main/java/org/wyldmods/toolutilities/common/compat/RailcraftCompat.java
+++ b/src/main/java/org/wyldmods/toolutilities/common/compat/RailcraftCompat.java
@@ -1,0 +1,16 @@
+package org.wyldmods.toolutilities.common.compat;
+
+import mods.railcraft.common.items.ItemCrowbar;
+
+import org.wyldmods.toolutilities.ToolUtilities;
+import org.wyldmods.toolutilities.common.Config;
+import org.wyldmods.toolutilities.common.recipe.ToolUpgrade;
+import org.wyldmods.toolutilities.common.recipe.ToolUpgradeRecipe;
+
+public class RailcraftCompat {
+
+    public static void addRailcraftRecipes()
+    {
+        ToolUpgradeRecipe.addUpgradeRecipe(ItemCrowbar.class, ToolUtilities.swordAreaItem, ToolUpgrade.SWORD_AOE, Config.swordAreaXP, Config.allowSwordAOE);
+    }
+}

--- a/src/main/java/org/wyldmods/toolutilities/common/compat/RailcraftCompat.java
+++ b/src/main/java/org/wyldmods/toolutilities/common/compat/RailcraftCompat.java
@@ -1,9 +1,11 @@
 package org.wyldmods.toolutilities.common.compat;
 
+import static org.wyldmods.toolutilities.common.Config.swordAreaXP;
+import static org.wyldmods.toolutilities.common.Config.allowSwordAOE;
+
 import mods.railcraft.common.items.ItemCrowbar;
 
 import org.wyldmods.toolutilities.ToolUtilities;
-import org.wyldmods.toolutilities.common.Config;
 import org.wyldmods.toolutilities.common.recipe.ToolUpgrade;
 import org.wyldmods.toolutilities.common.recipe.ToolUpgradeRecipe;
 
@@ -11,6 +13,6 @@ public class RailcraftCompat {
 
     public static void addRailcraftRecipes()
     {
-        ToolUpgradeRecipe.addUpgradeRecipe(ItemCrowbar.class, ToolUtilities.swordAreaItem, ToolUpgrade.SWORD_AOE, Config.swordAreaXP, Config.allowSwordAOE);
+        ToolUpgradeRecipe.addUpgradeRecipe(ItemCrowbar.class, ToolUtilities.swordAreaItem, ToolUpgrade.SWORD_AOE, swordAreaXP, allowSwordAOE);
     }
 }


### PR DESCRIPTION
I'm honestly not sure on the proper etiquette for this, so I apologize if I'm overstepping any boundaries here.

For your consideration, here's a small change that adds the ability for the Railcraft Crowbar to be upgraded with the Sword AoE Attack ability. As of Railcraft 9.4.0.0 or so, crowbars got two new damage focused enchantments making them an acceptable multipurpose weapon/wrench/crowbar.
